### PR TITLE
This commit does the following:

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -111,3 +111,33 @@ postgres://{{ .Values.postgresql.username }}:{{ .Values.postgresql.password }}@{
 postgres://{{ .Values.postgresql.username }}:{{ .Values.postgresql.password }}@{{ .Values.postgresql.hostname }}:{{ .Values.postgresql.port }}/%s{{ if .Values.postgresql.ssl }}?ssl=true&sslmode={{ .Values.postgresql.sslMode }}{{ end }}
 {{- end }}
 {{- end }}
+
+{{/*
+Helper functions for postgres
+*/}}
+{{- define "matrix.psqluser" -}}
+{{- $postgresSecret := (lookup "v1" "Secret" .Release.Namespace "postgres-db" ) | default dict -}}
+{{- $secretData := (get $postgresSecret "data" | default dict ) -}}
+{{- $username := (get $secretData "user") -}}
+
+{{- if $username -}}
+{{- $username -}}
+{{- else if .Values.postgresql.username -}}
+{{ .Values.postgresql.username }}
+{{- else -}}
+matrix
+{{- end -}}
+{{- end -}}
+
+{{- define "matrix.psqlpass" -}}
+{{- $postgresSecret := (lookup "v1" "Secret" .Release.Namespace "postgres-db" ) | default dict -}}
+{{- $secretData := (get $postgresSecret "data" | default dict ) -}}
+{{- $password := (get $secretData "password") -}}
+{{- if $password -}}
+{{- $password -}}
+{{- else if .Values.postgresql.password -}}
+{{- .Values.postgresql.password -}}
+{{- else -}}
+{{- randAlphaNum 32 -}}
+{{- end -}}
+{{- end -}}

--- a/templates/synapse/postgres-secret.yaml
+++ b/templates/synapse/postgres-secret.yaml
@@ -1,0 +1,10 @@
+kind: Secret
+apiVersion: v1
+type: Opaque
+metadata:
+  name: postgres-db
+  annotations:
+    helm.sh/resource-policy: keep
+data:
+  user: {{ include "matrix.psqluser" . | b64enc }}
+  password: {{ include "matrix.psqlpass" . | b64enc }}

--- a/templates/synapse/shared-secret.yaml
+++ b/templates/synapse/shared-secret.yaml
@@ -1,0 +1,12 @@
+kind: Secret
+apiVersion: v1
+type: Opaque
+metadata:
+  name: synapse-shared-secret
+  annotations:
+    helm.sh/resource-policy: keep
+data:
+  {{- $secret := (lookup "v1" "Secret" .Release.Namespace "synapse-shared-secret" ) | default dict }}
+  {{- $secretData := (get $secret "data" | default dict ) }}
+  {{- $sharedSecret := (get $secretData "sharedSecret" | default (randAlphaNum 32 | b64enc) ) }}
+  sharedSecret: {{ $sharedSecret | quote }}

--- a/values.yaml
+++ b/values.yaml
@@ -373,7 +373,7 @@ element:
   # Element Kubernetes resource settings
   image:
     repository: "vectorim/element-web"
-    tag: v1.7.12
+    tag: v1.10.14
     pullPolicy: IfNotPresent
   service:
     type: ClusterIP


### PR DESCRIPTION
* It provides support for creating a postgres secret on deploy of the
  helm chart.
* It uses the helm 'lookup' method to check to see if a secret already
  exists, so as not to overwrite it.